### PR TITLE
Fix form submitting for FileUploadSelector

### DIFF
--- a/src/client/js/tucana/Sync.FileUploadSelector.js
+++ b/src/client/js/tucana/Sync.FileUploadSelector.js
@@ -380,12 +380,13 @@ echopoint.tucana.FileUploadSelectorSync.Frame = Core.extend(
   {
     this._loadStage = echopoint.tucana.FileUploadSelectorSync._STAGE_UPLOADING;
     this.peer._form.target = this._frameElement.id;
-    this.peer._form.submit();
 
     if ( this.peer._table._submit )
     {
       this.peer._table._submit._renderButton( true, this.peer._table );
     }
+
+    this.peer._form.submit();
 
     if ( !Core.Web.Env.BROWSER_SAFARI && !Core.Web.Env.BROWSER_CHROME )
     {


### PR DESCRIPTION
Form.submit() must be called after re-render input (button), see #2 

This caused a problem in Chrome ver. 79 where calling form.submit() was removed from queue of events after re-render input (because function appendChild() in _renderButton() first removes this element and then adds its again).